### PR TITLE
Update GitHub action to use Node.js 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ outputs:
   text:
     description: 'A file content read from path'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'
 branding:
   icon: 'archive'


### PR DESCRIPTION
Node.js 20 is deprecated for GitHub Actions runners. This PR updates `action.yml` to target Node.js 24 instead.

---
*PR created automatically by Jules for task [575469503856292554](https://jules.google.com/task/575469503856292554) started by @TarasMazepa*